### PR TITLE
 Wrong parsing of Visual Studio version string

### DIFF
--- a/src/Pendletron.Vsix.LocateInTFS/VSPackage.cs
+++ b/src/Pendletron.Vsix.LocateInTFS/VSPackage.cs
@@ -119,9 +119,13 @@ namespace Pendletron.Vsix.LocateInTFS
 		{
 			var d = GetDteAsDynamic();
 			string version = d.Version;
-	        double result = 0;
-	        Double.TryParse(version, out result);
-	        return Convert.ToInt32(Math.Floor(result));
+			if (version.Contains("."))
+			{
+				version = version.Remove(version.IndexOf('.'));
+			}
+			int result = 0;
+			Int32.TryParse(version, out result);
+			return result;
 		}
 
 		public dynamic GetServiceAsDynamic(Type serviceInterfaceType)


### PR DESCRIPTION
On a system that uses a european culture info the version string "12.0" is converted to a double with the value 120. To fix this simply cut all parts after the dot and convert it directly to an int.